### PR TITLE
Added temporary Railways TFC compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,12 @@ repositories {
             includeGroup "dev.ftb.mods"
         }
     }
+    maven {
+        url "https://maven.ithundxr.dev/releases"
+        content {
+            includeGroup "com.railwayteam.railways"
+        }
+    }
     flatDir {
         dir 'libs'
     }
@@ -154,9 +160,9 @@ dependencies {
     modImplementation("dev.ftb.mods:ftb-teams-forge:${project.ftb_teams_version}") { transitive = false }
 
     modRuntimeOnly("com.jozufozu.flywheel:flywheel-forge-1.20.1:0.6.10-7")
-    modRuntimeOnly("curse.maven:create-328085:4835191") { transitive = false }
+    modRuntimeOnly("com.simibubi.create:create-1.20.1:0.5.1.f-26:all") { transitive = false }
     modImplementation("blank:Steam_Rails-1.5.3+forge-mc1.20.1") // fixed Accessor
-    // modImplementation("curse.maven:create-steam-n-rails-688231:4836196") // Does not work, mixin parse bug
+    // modImplementation("com.railwayteam.railways:Steam_Rails-forge-1.20.1:1.5.3+forge-mc1.20.1")  { transitive = false } // Does not work, mixin parse bug
 
     modRuntimeOnly("vazkii.patchouli:Patchouli:${project.minecraft_version}-${project.patchouli_version}-FORGE")
     modRuntimeOnly("top.theillusivec4.curios:curios-forge:${project.curios_version}+${project.minecraft_version}")

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,9 @@ repositories {
             includeGroup "dev.ftb.mods"
         }
     }
+    flatDir {
+        dir 'libs'
+    }
 }
 
 dependencies {
@@ -149,6 +152,11 @@ dependencies {
     modImplementation("dev.ftb.mods:ftb-chunks-forge:${project.ftb_chunks_version}") { transitive = false }
     modImplementation("dev.ftb.mods:ftb-library-forge:${project.ftb_library_version}") { transitive = false }
     modImplementation("dev.ftb.mods:ftb-teams-forge:${project.ftb_teams_version}") { transitive = false }
+
+    modRuntimeOnly("com.jozufozu.flywheel:flywheel-forge-1.20.1:0.6.10-7")
+    modRuntimeOnly("curse.maven:create-328085:4835191") { transitive = false }
+    modImplementation("blank:Steam_Rails-1.5.3+forge-mc1.20.1") // fixed Accessor
+    // modImplementation("curse.maven:create-steam-n-rails-688231:4836196") // Does not work, mixin parse bug
 
     modRuntimeOnly("vazkii.patchouli:Patchouli:${project.minecraft_version}-${project.patchouli_version}-FORGE")
     modRuntimeOnly("top.theillusivec4.curios:curios-forge:${project.curios_version}+${project.minecraft_version}")

--- a/src/main/java/com/allthemods/gravitas2/core/mixin/RailwaysModEnumMixin.java
+++ b/src/main/java/com/allthemods/gravitas2/core/mixin/RailwaysModEnumMixin.java
@@ -3,6 +3,7 @@ import com.allthemods.gravitas2.util.GregitasUtil;
 import com.railwayteam.railways.compat.Mods;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
@@ -13,6 +14,7 @@ public class RailwaysModEnumMixin
 {
     @Shadow(remap = false)
     @Final
+    @Mutable
     private static Mods[] $VALUES;
 
     @SuppressWarnings("SameParameterValue")

--- a/src/main/java/com/allthemods/gravitas2/core/mixin/RailwaysModEnumMixin.java
+++ b/src/main/java/com/allthemods/gravitas2/core/mixin/RailwaysModEnumMixin.java
@@ -1,0 +1,35 @@
+package com.allthemods.gravitas2.core.mixin;
+import com.allthemods.gravitas2.util.GregitasUtil;
+import com.railwayteam.railways.compat.Mods;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.Arrays;
+
+@Mixin(Mods.class)
+public class RailwaysModEnumMixin
+{
+    @Shadow(remap = false)
+    @Final
+    private static Mods[] $VALUES;
+
+    @SuppressWarnings("SameParameterValue")
+    @Invoker(value="<init>")
+    private static Mods create(String name, int ordinal, String fabricId)
+    {
+        throw new IllegalStateException("Unreachable");
+    }
+
+    static
+    {
+        var entry = create("TFC", $VALUES.length, "tfc");
+
+        GregitasUtil.RailwaysTFC = entry;
+
+        //noinspection ShadowFinalModification
+        $VALUES = Arrays.copyOf($VALUES, $VALUES.length + 1);
+        $VALUES[$VALUES.length-1] = entry;
+    }
+}

--- a/src/main/java/com/allthemods/gravitas2/core/mixin/RailwaysModSetupMixin.java
+++ b/src/main/java/com/allthemods/gravitas2/core/mixin/RailwaysModSetupMixin.java
@@ -1,0 +1,17 @@
+package com.allthemods.gravitas2.core.mixin;
+
+import com.allthemods.gravitas2.registry.TFCTrackCompat;
+import com.railwayteam.railways.ModSetup;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ModSetup.class)
+public class RailwaysModSetupMixin {
+
+    @Inject(method = "register()V", at = @At("TAIL"), remap = false)
+    private static void gregitas$registerTFC(CallbackInfo ci) {
+        TFCTrackCompat.register();
+    }
+}

--- a/src/main/java/com/allthemods/gravitas2/registry/TFCTrackCompat.java
+++ b/src/main/java/com/allthemods/gravitas2/registry/TFCTrackCompat.java
@@ -1,0 +1,38 @@
+package com.allthemods.gravitas2.registry;
+
+import com.allthemods.gravitas2.util.GregitasUtil;
+import com.railwayteam.railways.Railways;
+import com.railwayteam.railways.compat.tracks.GenericTrackCompat;
+import net.minecraft.resources.ResourceLocation;
+
+public class TFCTrackCompat extends GenericTrackCompat {
+    TFCTrackCompat() {
+        super("tfc");
+    }
+
+    @Override
+    protected boolean registerTracksAnyway() {
+        return super.registerTracksAnyway() || GregitasUtil.RailwaysTFC.isLoaded;
+    }
+
+    @Override
+    protected ResourceLocation getSlabLocation(String name) {
+        return asResource("wood/planks/" + name + "_slab");
+    }
+
+    private static boolean registered = false;
+    public static void register() {
+        if (registered) {
+            Railways.LOGGER.error("Duplicate registration of TerraFirmaCraft track compat");
+            return;
+        }
+        registered = true;
+        Railways.LOGGER.info("Registering tracks for TerraFirmaCraft");
+        new TFCTrackCompat().register(
+                "acacia", "ash", "aspen", "birch", "blackwood",
+                "chestnut", "douglas_fir", "hickory", "kapok", "mangrove",
+                "maple", "oak", "palm", "pine", "rosewood",
+                "sequoia", "spruce", "sycamore", "white_cedar", "willow"
+        );
+    }
+}

--- a/src/main/java/com/allthemods/gravitas2/util/GregitasUtil.java
+++ b/src/main/java/com/allthemods/gravitas2/util/GregitasUtil.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.item.TagPrefixItem;
+import com.railwayteam.railways.compat.Mods;
 import net.dries007.tfc.common.capabilities.heat.HeatCapability;
 import net.dries007.tfc.common.capabilities.heat.IHeat;
 import net.minecraft.resources.ResourceLocation;
@@ -13,6 +14,7 @@ import net.minecraftforge.registries.MissingMappingsEvent;
 
 public class GregitasUtil {
 
+    public static Mods RailwaysTFC;
     public static <T> void remap(MissingMappingsEvent.Mapping<T> mapping) {
         ResourceLocation key = mapping.getKey();
         T newThing = remapId(key, mapping.getRegistry());

--- a/src/main/java/com/allthemods/gravitas2/util/GregitasUtil.java
+++ b/src/main/java/com/allthemods/gravitas2/util/GregitasUtil.java
@@ -1,14 +1,8 @@
 package com.allthemods.gravitas2.util;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
-import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
-import com.gregtechceu.gtceu.api.item.TagPrefixItem;
 import com.railwayteam.railways.compat.Mods;
-import net.dries007.tfc.common.capabilities.heat.HeatCapability;
-import net.dries007.tfc.common.capabilities.heat.IHeat;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.MissingMappingsEvent;
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -68,3 +68,9 @@ license = "LGPLv3" # Want to make your mod open source? Check out https://choose
         versionRange = "[3.1.0-beta,)"
         ordering = "AFTER"
         side = "BOTH"
+    [[dependencies.gregitas_core]]
+        modId = "railways"
+        mandatory = true
+        versionRange = "1.5.3+forge-mc1.20.1"
+        ordering = "AFTER"
+        side = "BOTH"

--- a/src/main/resources/gregitas_core.mixins.json
+++ b/src/main/resources/gregitas_core.mixins.json
@@ -11,6 +11,8 @@
     "MixinHelpersMixin",
     "PlaceBlockSpecialPacketMixin",
     "PlacedItemBlockEntityMixin",
+    "RailwaysModEnumMixin",
+    "RailwaysModSetupMixin",
     "TagPrefixMixin",
     "TagPrefixOreTypeAccessor"
   ],


### PR DESCRIPTION
- Locked dependency to this exact railways version
- Cursed Enum Mixin ([by gigaherz](https://github.com/gigaherz/JsonThings/blob/master/src/main/java/dev/gigaherz/jsonthings/mixin/ResourcePackTypeExtender.java))

All this stuff can be removed when Steam and Rails add their compat.